### PR TITLE
Rename tex.BufferX new function.

### DIFF
--- a/tex/bufferx.go
+++ b/tex/bufferx.go
@@ -3,6 +3,7 @@ package tex
 import (
 	"encoding/binary"
 	"errors"
+	"github.com/pinealctx/neptune/tex/pkg"
 	"math"
 )
 
@@ -94,7 +95,7 @@ type IBufferX interface {
 
 //BufferX buffer implement
 type BufferX struct {
-	buffer *Buffer
+	buffer *pkg.Buffer
 }
 
 //Len : buffer len
@@ -394,28 +395,28 @@ func (b *BufferX) WriteF64(v float64) {
 	b.WriteU64(math.Float64bits(v))
 }
 
-//NewBufferXFrom new buffer from an exist bytes
-//as packer
-func NewBufferXFrom(data []byte) *BufferX {
-	var buffer = NewBuffer(data)
+//NewReadableBuffer new buffer from existed bytes to read.
+//Use existed bytes to fill buffer, the buffer is always used as read stream.
+func NewReadableBuffer(data []byte) *BufferX {
+	var buffer = pkg.NewBuffer(data)
 	var bufferX = &BufferX{buffer: buffer}
 	return bufferX
 }
 
-//NewBufferX new buffer with a default size
+//NewBuffer new buffer with a default size
 //as unpack
-func NewBufferX() *BufferX {
+func NewBuffer() *BufferX {
 	var data = make([]byte, defaultByteBuff)
-	var buffer = NewBuffer(data)
+	var buffer = pkg.NewBuffer(data)
 	buffer.Reset()
 	var bufferX = &BufferX{buffer: buffer}
 	return bufferX
 }
 
-//NewSpecBufferX new small
-func NewSpecBufferX(n int) *BufferX {
-	var data = make([]byte, n)
-	var buffer = NewBuffer(data)
+//NewSizedBuffer : new buffer with specific size
+func NewSizedBuffer(size int) *BufferX {
+	var data = make([]byte, size)
+	var buffer = pkg.NewBuffer(data)
 	buffer.Reset()
 	var bufferX = &BufferX{buffer: buffer}
 	return bufferX

--- a/tex/bufferx_test.go
+++ b/tex/bufferx_test.go
@@ -45,7 +45,7 @@ func writeVarI32() []int {
 	var l = len(i32)
 	var s = make([]int, l)
 	for i := 0; i < l; i++ {
-		var x = NewSpecBufferX(6)
+		var x = NewSizedBuffer(6)
 		x.WriteVarI32(i32[i])
 		s[i] = x.Len()
 		var r, _ = x.ReadVarI32()
@@ -95,7 +95,7 @@ func writeI32() []int {
 	var l = len(i32)
 	var s = make([]int, l)
 	for i := 0; i < l; i++ {
-		var x = NewSpecBufferX(6)
+		var x = NewSizedBuffer(6)
 		x.WriteI32(i32[i])
 		s[i] = x.Len()
 		var r, _ = x.ReadI32()

--- a/tex/pkg/buffer.go
+++ b/tex/pkg/buffer.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package tex
+package pkg
 
 // Simple byte buffer for marshaling data.
 


### PR DESCRIPTION
1. new function names are more comprehensible.