### PR TITLE
Convert BytesMsg as IMsg, not pointer of BytesMsg

### DIFF
--- a/stcp/README.md
+++ b/stcp/README.md
@@ -732,7 +732,7 @@ func (c *MyCustomConnIO) PutMsg(msg stcp.IMsg) error {
     }
     
     switch m := msg.(type) {
-    case *stcp.BytesMsg:
+    case stcp.BytesMsg:
         // 处理字节消息
         return c.handleBytesMsg(m)
     default:
@@ -781,9 +781,9 @@ func (c *MyCustomConnIO) PutMsg(msg stcp.IMsg) error {
         return fmt.Errorf("MyCustomConnIO.PutMsg: nil message")
     }
     
-    bsMsg, ok := msg.(*stcp.BytesMsg)
+    bsMsg, ok := msg.(stcp.BytesMsg)
     if !ok {
-        return fmt.Errorf("MyCustomConnIO.PutMsg: expected *BytesMsg, got %s", msg.Name())
+        return fmt.Errorf("MyCustomConnIO.PutMsg: expected BytesMsg, got %s", msg.Name())
     }
     
     return c.processBytesMsg(bsMsg)

--- a/stcp/basic.go
+++ b/stcp/basic.go
@@ -14,12 +14,12 @@ type BytesMsg struct {
 }
 
 // NewBytesMsg : new bytes message
-func NewBytesMsg(bs []byte) *BytesMsg {
-	return &BytesMsg{Bs: bs}
+func NewBytesMsg(bs []byte) BytesMsg {
+	return BytesMsg{Bs: bs}
 }
 
 // Name : message name
-func (x *BytesMsg) Name() string {
+func (x BytesMsg) Name() string {
 	return "BytesMsg"
 }
 

--- a/stcp/qsendconn.go
+++ b/stcp/qsendconn.go
@@ -48,15 +48,12 @@ func (x *QSendConn) PutMsg(msg IMsg) error {
 	if msg == nil {
 		return fmt.Errorf("QSendConn.PutMsg: nil message")
 	}
-	bsMsg, ok := msg.(*BytesMsg)
+	bsMsg, ok := msg.(BytesMsg)
 	if !ok {
-		return fmt.Errorf("QSendConn.PutMsg: invalid message name: %s, expected *BytesMsg", msg.Name())
-	}
-	if bsMsg == nil {
-		return fmt.Errorf("QSendConn.PutMsg: nil *BytesMsg")
+		return fmt.Errorf("QSendConn.PutMsg: invalid message name: %s, expected BytesMsg", msg.Name())
 	}
 	if len(bsMsg.Bs) == 0 {
-		return fmt.Errorf("QSendConn.PutMsg: empty *BytesMsg")
+		return fmt.Errorf("QSendConn.PutMsg: empty BytesMsg")
 	}
 	return x.sendQ.Push(bsMsg.Bs)
 }


### PR DESCRIPTION
Struct has more performance than pointer if there are few fields in struct.